### PR TITLE
Using published images in dockerhub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,11 @@ services:
       - 8080:8080
       
   front:
-    image: todo-list-frontend
+    image: unqpdes/todo-list-front
 
   back:
-    build: "../2018-redux-todo-list-backend/"
-    # image: todo-list-backend
+    # build: "../2018-redux-todo-list-backend/"
+    image: unqpdes/todo-list-back
     environment: 
       - MONGO_URL=mongodb://mongodb/pdes-todos
 

--- a/traefik/traefik.toml
+++ b/traefik/traefik.toml
@@ -16,7 +16,7 @@ defaultEntryPoints = ["http"]
 [backends]
   [backends.backend1]
     [backends.backend1.servers.server1]
-    url = "http://front:3000"
+    url = "http://front:5000"
   [backends.backend2]
     [backends.backend2.servers.server1]
     url = "http://back:3001"


### PR DESCRIPTION
@aitrusgit tengo una única duda, el cambio de puerto en el front.

Intenté levantar el compose así como estaba, contra las imágenes buildeadas por travis desde el branch "dockerized" de cada módulo (front y back), y pasaba que al pegarle a localhost:8080 (traeffik), me tiraba bad gateway.
Mirando el log del compose, veía que el front levantaba en el 5000 y no en el 3000 como estaba configurado traeffik, así que lo cambié.

No se si es que el compose laburaba contra el front en modo webpack (wds) y eso era puerto 3000, pero ahora con "serve" usa el 5000 ?

En fin.. se te ocurre algún motivo para no hacer este cambio ?